### PR TITLE
Corner trains

### DIFF
--- a/ts/play.train.ts
+++ b/ts/play.train.ts
@@ -101,10 +101,10 @@ module trains.play {
             var speedDeadlockCounter = 0;
             while (speed > 0.00001) {
                 if(speedDeadlockCounter++ > 10){
-                     //throw "SpeedDeadlock";
-                     console.log("SpeedDeadlock");
-                     this.hammerTime();
-                     break;
+                    // This needs to be cleaned up/fixed now that we can detect it!
+                    console.log("SpeedDeadlock");
+                    this.hammerTime();
+                    break;
                 }
 
                 var column = GameBoard.getGridCoord(this.coords.currentX);
@@ -239,10 +239,7 @@ module trains.play {
             var direction = this.magicBullshitCompareTo(angleLast, angle) * ((Math.abs(angleLast - angle) > Math.PI) ? -1 : 1);
 
             //If we end up with a direction of 0, it means we are stuck!
-            // Normally happens after a train is placed on a corner.
-            // Simple fix, force it to move!
             if(direction === 0) {
-                console.log("Direction zero issue");
                 direction = -1;
             }
 

--- a/ts/play.train.ts
+++ b/ts/play.train.ts
@@ -40,8 +40,8 @@ module trains.play {
                 this.coords = {
                     currentX: cell.x + (trains.play.gridSize / 2),
                     currentY: cell.y + (trains.play.gridSize / 2),
-                    previousX: cell.x,
-                    previousY: cell.y - 1 //Cos we never want to be the centre of attention
+                    previousX: cell.x + (trains.play.gridSize / 2),
+                    previousY: cell.y + (trains.play.gridSize / 2) - 1, //Cos we never want to be the centre of attention
                 };
 
                 if (Math.floor(Math.random() * 10) === 0) {
@@ -98,7 +98,15 @@ module trains.play {
             speed *= this.trainSpeed;
             //Super small speeds cause MAJOR problems with the game loop.
             // First occurrence of this bug, speed was 1.13e-14!!!!!
+            var speedDeadlockCounter = 0;
             while (speed > 0.00001) {
+                if(speedDeadlockCounter++ > 10){
+                     //throw "SpeedDeadlock";
+                     console.log("SpeedDeadlock");
+                     this.hammerTime();
+                     break;
+                }
+
                 var column = GameBoard.getGridCoord(this.coords.currentX);
                 var row = GameBoard.getGridCoord(this.coords.currentY);
                 var cell = GameBoard.getCell(column, row);
@@ -108,6 +116,7 @@ module trains.play {
                         this.waitForTrafficToClear(result.coords);
                         return;
                     }
+
                     this.coords = result.coords;
                     speed = result.remainingSpeed;
                 }
@@ -228,6 +237,14 @@ module trains.play {
             // We then multiply by -1 if the difference between the 2 angles in greater than Math.PI
             // This fixes a strange bug :)
             var direction = this.magicBullshitCompareTo(angleLast, angle) * ((Math.abs(angleLast - angle) > Math.PI) ? -1 : 1);
+
+            //If we end up with a direction of 0, it means we are stuck!
+            // Normally happens after a train is placed on a corner.
+            // Simple fix, force it to move!
+            if(direction === 0) {
+                console.log("Direction zero issue");
+                direction = -1;
+            }
 
             //We can then use the fact that (in radians) angle=lengthOfArc/radius to find what angle is needed
             // To move us 'speed' along the arc


### PR DESCRIPTION
The issue with trains spawning on corners was the angle of previous vs. now was the same, causing direction to be zero, canceling out all movement.

2 part fix:
 - Add better logic to the corner movement function, allowing it to recover in a semi-sensible way.
 - Fix the spawn logic to place the previous coords within sensible limits (1 pixel offset), allowing the angles of current vs previous to not be equal. (Aka, the behavior we wanted from the start!)

Additionally, added deadlock detection on the speed loop. This doesn't fix the issue, but will detect and break out of the deadloop, stopping the browser from crashing.

This resolves issue #13 